### PR TITLE
Problemas com CaseSensitive

### DIFF
--- a/src/Controllers/Controller.js
+++ b/src/Controllers/Controller.js
@@ -1,4 +1,4 @@
-import store from '../store';
+import store from '../Store';
 
 class Controller {
 	constructor() {

--- a/src/Router/index.js
+++ b/src/Router/index.js
@@ -2,8 +2,8 @@ import Vue from 'vue';
 import VueRouter from 'vue-router';
 
 // -> import views
-import HomeController from '../controllers/HomeController';
-import AuthController from '../controllers/AuthController';
+import HomeController from '../Controllers/HomeController';
+import AuthController from '../Controllers/AuthController';
 
 Vue.use(VueRouter);
 

--- a/src/Store/index.js
+++ b/src/Store/index.js
@@ -8,7 +8,7 @@ import VuexPersistence from 'vuex-persist';
 Vue.use(Vuex);
 
 // -> import helpers
-import { rename } from '../helpers/Misc';
+import { rename } from '@/Helpers/Misc';
 
 const STORAGE = new VuexPersistence({
 	storage: window.localStorage

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -1,4 +1,4 @@
-import { rename } from './helpers/Misc';
+import { rename } from './Helpers/Misc';
 
 export const _CONTROLLER = (_controllerName) => {
 	if (typeof _controllerName === 'string') {

--- a/src/config/Settings.js
+++ b/src/config/Settings.js
@@ -1,5 +1,5 @@
-import Anonymous from '../helpers/Anonymous';
-import Interactions from '../helpers/Interactions';
+import Anonymous from '../Helpers/Anonymous';
+import Interactions from '../Helpers/Interactions';
 
 export const PROJECT_NAME = '';
 export const CLIENT_NAME = '';

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,7 @@ window._ = require('lodash');
 
 import Vue from 'vue';
 import App from './App.vue';
-import Router from './router';
+import Router from './Router';
 import Store from './store';
 
 // -> begin: vue config

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,7 @@ window._ = require('lodash');
 import Vue from 'vue';
 import App from './App.vue';
 import Router from './Router';
-import Store from './store';
+import Store from './Store';
 
 // -> begin: vue config
 Vue.config.productionTip = false;

--- a/src/views/Auth/index.js
+++ b/src/views/Auth/index.js
@@ -1,8 +1,8 @@
 // @ is an alias to /src
 import LayoutContainer from '@/views/_Components/layout/Container/index.vue';
 
-import { Masks } from '@/helpers/Mask';
-import { isTestNumber } from "@/helpers/Misc";
+import { Masks } from '@/Helpers/Mask';
+import { isTestNumber } from "@/Helpers/Misc";
 
 export default {
 	name: 'Auth',


### PR DESCRIPTION
**Motivo**
O CaseSensitivePathPlugin está encontrando erro nas chamadas das pastas e arquivos.

**Solução**
Ajustar a nomenclaturas das pastas e arquivos que estão sendo importados no código.